### PR TITLE
Progress bars

### DIFF
--- a/KPT/ProjectFolder.cs
+++ b/KPT/ProjectFolder.cs
@@ -173,11 +173,13 @@ namespace KPT
         public static void LoadStrings(object sender, EventArgs e)
         {
 
-            BackgroundWorker worker;
+            BackgroundWorker worker = null;
+            DoWorkEventArgs eventArgs = null;
 
             if (sender is BackgroundWorker)
             {
                 worker = sender as BackgroundWorker;
+                eventArgs = e as DoWorkEventArgs;
             }
             else
             {
@@ -192,7 +194,7 @@ namespace KPT
             {
                 string errorMessage = string.Format("Could not find directory {0}.", dialogueFileDir);
                 MessageBox.Show(errorMessage, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-                //return false; // no longer returning bool, so we need another way of handling errors here
+                eventArgs.Result = false;
             }
 
             var nameCollection = new StringCollection();
@@ -223,6 +225,8 @@ namespace KPT
                 {
                     if (worker.WorkerSupportsCancellation && worker.CancellationPending)
                     {
+                        eventArgs.Result = false;
+                        MessageBox.Show("Load strings cancelled");
                         return;
                     }
                 }
@@ -265,6 +269,7 @@ namespace KPT
             }
 
             Thread.Sleep(1000); // this is another aesthetic sleep, ensuring the the progress bar does not disappear before the user can see it completing
+            eventArgs.Result = true;
         }
 
         public static bool DumpISO(string isoFileName)

--- a/KPT/ProjectForm.cs
+++ b/KPT/ProjectForm.cs
@@ -252,8 +252,6 @@ namespace KPT
             {
                 LoadImages(null, null);
             }
-
-            MessageBox.Show("Images loaded!");
         }
 
         public void LoadImages(object sender, EventArgs e)
@@ -296,6 +294,7 @@ namespace KPT
                 {
                     if (worker.WorkerSupportsCancellation && worker.CancellationPending)
                     {
+                        MessageBox.Show("Load images cancelled");
                         return;
                     }
                 }
@@ -330,6 +329,8 @@ namespace KPT
 
 
             }
+
+            MessageBox.Show("Images loaded!");
 
         }
 

--- a/KPT/ProjectForm.cs
+++ b/KPT/ProjectForm.cs
@@ -57,14 +57,35 @@ namespace KPT
 
         private void LoadStrings_Click(object sender, EventArgs e)
         {
-            if (ProjectFolder.LoadStrings())
+            bool success = false;
+
+            if (DebugSettings.USE_BACKGROUND_WORKERS)
             {
-                MessageBox.Show("Strings loaded!");
+                worker = new BackgroundWorker();
+                worker.WorkerReportsProgress = true;
+                worker.DoWork += ProjectFolder.LoadStrings;
+                worker.ProgressChanged += UpdateProgressBar;
+                worker.RunWorkerCompleted += WorkCompleted;
+                worker.WorkerSupportsCancellation = true;
+                worker.RunWorkerAsync();
+
+                progressBar = new ProgressBar(worker);
+                progressBar.ShowDialog();
             }
             else
             {
-                MessageBox.Show("There was an error while loading strings.");
+                //success = ProjectFolder.LoadStrings(null, null);
             }
+
+            //if (success)
+            //{
+            //    MessageBox.Show("Strings loaded!");
+            //}
+            //else
+            //{
+            //    MessageBox.Show("There was an error while loading strings.");
+            //}
+
         }
 
         private void DumpISO_Click(object sender, EventArgs e)

--- a/KPT/ProjectForm.cs
+++ b/KPT/ProjectForm.cs
@@ -47,7 +47,7 @@ namespace KPT
             }
             else
             {
-                MessageBox.Show("RebuildCPKs no longer suppoerted without BackgroundWorker");
+                MessageBox.Show("RebuildCPKs no longer supported without BackgroundWorker");
             }
 
         }
@@ -85,7 +85,7 @@ namespace KPT
             }
             else
             {
-                MessageBox.Show("LoadStrings no longer suppoerted without BackgroundWorker");
+                MessageBox.Show("LoadStrings no longer supported without BackgroundWorker");
             }
 
 

--- a/KPT/ProjectForm.cs
+++ b/KPT/ProjectForm.cs
@@ -32,15 +32,24 @@ namespace KPT
 
         private void RebuildCPKs_Click(object sender, EventArgs e)
         {
-            if (ProjectFolder.RebuildCPKs())
+            if (DebugSettings.USE_BACKGROUND_WORKERS)
             {
-                MessageBox.Show("CPKs rebuilt!");
+                worker = new BackgroundWorker();
+                worker.WorkerReportsProgress = true;
+                worker.DoWork += ProjectFolder.RebuildCPKs;
+                worker.ProgressChanged += UpdateProgressBar;
+                worker.RunWorkerCompleted += RebuildCPKsCompleted;
+                worker.WorkerSupportsCancellation = true;
+                worker.RunWorkerAsync();
+
+                progressBar = new ProgressBar(worker);
+                progressBar.ShowDialog();
             }
             else
             {
-                MessageBox.Show("There was an error while rebuilding the CPKs.");
+                MessageBox.Show("RebuildCPKs no longer suppoerted without BackgroundWorker");
             }
-            
+
         }
 
         private void DumpStrings_Click(object sender, EventArgs e)
@@ -380,6 +389,22 @@ namespace KPT
             else
             {
                 MessageBox.Show("There was an error while loading strings.");
+            }
+        }
+
+        public void RebuildCPKsCompleted(object sender, RunWorkerCompletedEventArgs e)
+        {
+            progressBar.Close();
+
+            bool success = (bool)e.Result;
+
+            if (success)
+            {
+                MessageBox.Show("CPK rebuilt!");
+            }
+            else
+            {
+                MessageBox.Show("There was an error while rebuilding CPKs.");
             }
         }
 

--- a/KPT/ProjectForm.cs
+++ b/KPT/ProjectForm.cs
@@ -57,7 +57,6 @@ namespace KPT
 
         private void LoadStrings_Click(object sender, EventArgs e)
         {
-            bool success = false;
 
             if (DebugSettings.USE_BACKGROUND_WORKERS)
             {
@@ -65,26 +64,22 @@ namespace KPT
                 worker.WorkerReportsProgress = true;
                 worker.DoWork += ProjectFolder.LoadStrings;
                 worker.ProgressChanged += UpdateProgressBar;
-                worker.RunWorkerCompleted += WorkCompleted;
+                worker.RunWorkerCompleted += LoadStringsCompleted;
                 worker.WorkerSupportsCancellation = true;
                 worker.RunWorkerAsync();
 
                 progressBar = new ProgressBar(worker);
                 progressBar.ShowDialog();
+
+
+
             }
             else
             {
-                //success = ProjectFolder.LoadStrings(null, null);
+                MessageBox.Show("LoadStrings no longer suppoerted without BackgroundWorker");
             }
 
-            //if (success)
-            //{
-            //    MessageBox.Show("Strings loaded!");
-            //}
-            //else
-            //{
-            //    MessageBox.Show("There was an error while loading strings.");
-            //}
+
 
         }
 
@@ -370,6 +365,22 @@ namespace KPT
         public void WorkCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
             progressBar.Close();
+        }
+
+        public void LoadStringsCompleted(object sender, RunWorkerCompletedEventArgs e)
+        {
+            progressBar.Close();
+
+            bool success = (bool)e.Result;
+
+            if (success)
+            {
+                MessageBox.Show("Strings loaded!");
+            }
+            else
+            {
+                MessageBox.Show("There was an error while loading strings.");
+            }
         }
 
     }


### PR DESCRIPTION
Progress bars were repeatedly requested by test users, so this implements progress bars for the functions which are most frequently used, Progress bars for functions which are only intended to be used once or twice may be added later, but they are not currently a priority.

The changes to function signatures required to enable the usage of BackgroundWorkers has the side effect of making LoadStrings and RebuildCPKs no longer usage when UseBackgroundWokers is disabled. Not expected to be a huge problem, but it is worth noting.